### PR TITLE
Avoid error when missing some annotations

### DIFF
--- a/plugin/src/components/ApplicationDetailsCard.tsx
+++ b/plugin/src/components/ApplicationDetailsCard.tsx
@@ -41,14 +41,14 @@ const ApplicationDetailsCard: React.FC<{ application: Application }> = ({ applic
 
     function getBuildTimestamp(application: Application): string | null {
         if (application && application.metadata) {
-            return application.metadata.annotations["app.quarkus.io/build-timestamp"];
+            return application.metadata.annotations?.["app.quarkus.io/build-timestamp"];
         }
         return null;
     }
 
     function getApplicationVersion(application: Application): string | null {
         if (application && application.metadata) {
-            return application.metadata.annotations["app.kubernetes.io/version"];
+            return application.metadata.annotations?.["app.kubernetes.io/version"];
         }
         return null;
     }
@@ -140,12 +140,12 @@ const ApplicationDetailsCard: React.FC<{ application: Application }> = ({ applic
                         <Card>
                             <CardTitle>Frameworks</CardTitle>
                             <CardBody>
-                                {application.metadata.annotations['camel/camel-core-version'] && <TextContent><strong>Camel: </strong> {application.metadata.annotations['camel/camel-core-version']}</TextContent>}
-                                {application.metadata.annotations['camel/quarkus-platform'] && <TextContent><strong>Quarkus Platform: </strong> {application.metadata.annotations['camel/quarkus-platform']}</TextContent>}
-                                {application.metadata.annotations['camel/camel-quarkus'] && <TextContent><strong>Camel Quarkus: </strong> {application.metadata.annotations['camel/camel-quarkus']}</TextContent>}
+                                {application.metadata.annotations?.['camel/camel-core-version'] && <TextContent><strong>Camel: </strong> {application.metadata.annotations['camel/camel-core-version']}</TextContent>}
+                                {application.metadata.annotations?.['camel/quarkus-platform'] && <TextContent><strong>Quarkus Platform: </strong> {application.metadata.annotations['camel/quarkus-platform']}</TextContent>}
+                                {application.metadata.annotations?.['camel/camel-quarkus'] && <TextContent><strong>Camel Quarkus: </strong> {application.metadata.annotations['camel/camel-quarkus']}</TextContent>}
 
-                                {application.metadata.annotations['camel/camel-spring-boot-version'] && <TextContent><strong>Camel Spring Boot: </strong> {application.metadata.annotations['camel/camel-spring-boot-version']}</TextContent>}
-                                {application.metadata.annotations['camel/spring-boot-version'] && <TextContent><strong>Spring Boot: </strong> {application.metadata.annotations['camel/spring-boot-version']}</TextContent>}
+                                {application.metadata.annotations?.['camel/camel-spring-boot-version'] && <TextContent><strong>Camel Spring Boot: </strong> {application.metadata.annotations['camel/camel-spring-boot-version']}</TextContent>}
+                                {application.metadata.annotations?.['camel/spring-boot-version'] && <TextContent><strong>Spring Boot: </strong> {application.metadata.annotations['camel/spring-boot-version']}</TextContent>}
                             </CardBody>
                         </Card>
                     </div>

--- a/plugin/src/components/ApplicationList.tsx
+++ b/plugin/src/components/ApplicationList.tsx
@@ -257,7 +257,7 @@ export const ApplicationList: React.FC<ApplicationListProps> = ({ apps }) => {
                 <Td dataLabel={columnNames.exchangesTotal}>{app.exchangesTotal}</Td>
                 <Td dataLabel={columnNames.cpu}>{app.cpu}</Td>
                 <Td dataLabel={columnNames.memory}>{app.memory}</Td>
-                <Td dataLabel={columnNames.runtime}>Camel: {app.metadata.annotations['camel/camel-core-version']}</Td>
+                <Td dataLabel={columnNames.runtime}>Camel: {app.metadata.annotations?.['camel/camel-core-version']}</Td>
               </Tr>
             ))}
           </Tbody>


### PR DESCRIPTION
This avoid js errors on the camel panel when the annotations are missing.